### PR TITLE
Add Dockerfile for building a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:alpine as compile
+
+RUN apk --no-cache add make git
+
+COPY . src/github.com/jamesnetherton/homehub-cli
+
+ENV CGO_ENABLED=0
+RUN cd src/github.com/jamesnetherton/homehub-cli && \
+    make build && \
+    cp build/homehub-cli /go/bin/homehub-cli
+
+
+FROM scratch
+
+COPY --from=compile /go/bin/homehub-cli /homehub-cli
+
+ENTRYPOINT ["/homehub-cli"]


### PR DESCRIPTION
A two-step process is used in order to have a minimal image as the end result. The resulting image is 7 MB in size and only contains the `homehub-cli` binary.

Quick test after building the image locally:

    [jeppe@reventon ~]$ docker run --rm homehub About
    Version:            0.5.0
    Compatible with:    SG4B1000B316
    Build date:         11/01/2018
    Revision:           99fc4f9
    [jeppe@reventon ~]$ docker run --rm homehub Version --password=$PASS
    Home Hub 60 Type A
    [jeppe@reventon ~]$ docker run --rm homehub SoftwareVersion --password=$PASS
    SG4B1000B316

Fixes #15.